### PR TITLE
chore: ignore `.idea` in `.gitignore` config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea


### PR DESCRIPTION
### What has changed and why?

- Directory `.idea` set to be ignored in `.gitignore` config file

### Branch Name Validation

- [ ] Branch name pattern: `{type}/{JIRA-ID}` or `{type}/issue-{GITHUB-ISSUE-ID}`

### PR Title Validation

- [ ] PR title pattern: `{type}: [{JIRA-ID}] Description` or `{type}: [#{GITHUB-ISSUE-ID}] Description`

### Only check what is relevant for this PR

- [ ] Styling verified for different screen sizes and browsers
- [ ] Functionality verified for different screen sizes and browsers
- [ ] Relevant unit tests added/updated
- [ ] Storybook files added/updated
